### PR TITLE
Create release.md

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -4,4 +4,5 @@ This document describes the release process for the new versions of the AGLint l
 
 1. Update the version number in the `package.json` file regarding the [semver](https://semver.org/) rules.
 2. Fill the `CHANGELOG.md` file with the changes made since the last release by following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) rules.
-3. Push the changes to the `master` branch and create a new tag with the version number (e.g. `v1.0.0`) to trigger the [release workflow](https://github.com/AdguardTeam/AGLint/blob/master/.github/workflows/release.yml).
+3. Push the changes to the `master` branch.
+4. Create a new tag with the version number (e.g. `v1.0.0`) to trigger the [release workflow](https://github.com/AdguardTeam/AGLint/blob/master/.github/workflows/release.yml).


### PR DESCRIPTION
It's worth considering not to "overload" the README and keep it just for the basic introductory stuff.

I created a `docs` folder where we can later upload additional documentation, e.g. AST structure, etc.