### PR TITLE
Ignore some paths when run tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+    paths-ignore: ['*.md', 'docs/**']
   pull_request:
     branches:
       - master
+    paths-ignore: ['*.md', 'docs/**']
 
 jobs:
   lint:


### PR DESCRIPTION
The test CI runs completely unnecessarily if e.g. md files are modified, but perhaps other paths should be excluded. Do we have to ignore other routes as well?