### PR TITLE
Integrate ECSSTree

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "type": "module",
     "main": "dist/aglint.cjs",
     "module": "dist/aglint.esm.js",
+    "browser": "dist/aglint.iife.min.js",
     "types": "dist/aglint.d.ts",
     "bin": "dist/cli.js",
     "files": [
@@ -40,7 +41,7 @@
         "lint": "eslint . --ext .ts",
         "test": "jest --runInBand .",
         "coverage": "jest --coverage",
-        "build": "yarn rimraf dist && tsc --declaration --emitDeclarationOnly --outdir dist/types && yarn rollup --config rollup.config.ts --configPlugin typescript && yarn terser dist/aglint.iife.js --output dist/aglint.iife.min.js && yarn terser dist/aglint.umd.js --output dist/aglint.umd.min.js && yarn rimraf dist/types"
+        "build": "yarn rimraf dist && tsc --declaration --emitDeclarationOnly --outdir dist/types && yarn rollup --config rollup.config.ts --configPlugin typescript && yarn rimraf dist/types"
     },
     "devDependencies": {
         "@babel/core": "^7.20.5",
@@ -50,10 +51,9 @@
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
-        "@rollup/plugin-terser": "^0.2.0",
+        "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^9.0.2",
         "@types/clone-deep": "^4.0.1",
-        "@types/css-tree": "^1.0.7",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.0",
         "@types/globrex": "^0.1.2",
@@ -79,16 +79,15 @@
         "rollup-plugin-dts": "^5.0.0",
         "rollup-plugin-node-externals": "^5.0.1",
         "rollup-plugin-polyfill-node": "^0.11.0",
-        "terser": "^5.16.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4"
     },
     "dependencies": {
+        "@adguard/ecss-tree": "^1.0.8",
         "chalk": "4.1.2",
         "clone-deep": "^4.0.1",
         "commander": "^9.4.1",
-        "css-tree": "^2.2.1",
         "deepmerge": "^4.2.2",
         "fs-extra": "^11.1.0",
         "glob": "^8.0.3",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,6 +14,7 @@ import nodePolyfills from 'rollup-plugin-polyfill-node';
 import alias from '@rollup/plugin-alias';
 import { getBabelOutputPlugin } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
+import terser from '@rollup/plugin-terser';
 
 const commonPlugins = [externals(), commonjs({ sourceMap: false }), resolve({ preferBuiltins: false })];
 
@@ -99,7 +100,9 @@ const browserPlugins = [
     // The build of CSSTree is a bit complicated (patches, require "emulation", etc.),
     // so here we only specify the pre-built version by an alias
     alias({
-        entries: [{ find: 'css-tree', replacement: 'node_modules/css-tree/dist/csstree.esm.js' }],
+        entries: [
+            { find: '@adguard/ecss-tree', replacement: 'node_modules/@adguard/ecss-tree/dist/ecsstree.umd.min.js' },
+        ],
     }),
     getBabelOutputPlugin({
         presets: [
@@ -112,7 +115,7 @@ const browserPlugins = [
         ],
         allowAllFormats: true,
     }),
-    // TODO: Terser plugin https://github.com/rollup/plugins/issues/1366
+    terser(),
 ];
 
 // Browser-friendly UMD build
@@ -120,7 +123,7 @@ const aglintUmd = {
     input: './src/index.browser.ts',
     output: [
         {
-            file: './dist/aglint.umd.js',
+            file: './dist/aglint.umd.min.js',
             name: 'AGLint',
             format: 'umd',
             sourcemap: false,
@@ -134,7 +137,7 @@ const aglintIife = {
     input: './src/index.browser.ts',
     output: [
         {
-            file: './dist/aglint.iife.js',
+            file: './dist/aglint.iife.min.js',
             name: 'AGLint',
             format: 'iife',
             sourcemap: false,

--- a/src/parser/cosmetic/body/css.ts
+++ b/src/parser/cosmetic/body/css.ts
@@ -13,7 +13,7 @@ import {
     toPlainObject,
     fromPlainObject,
     MediaQueryListPlain,
-} from 'css-tree';
+} from '@adguard/ecss-tree';
 import { AdblockSyntax } from '../../../utils/adblockers';
 import {
     CSS_BLOCK_CLOSE,

--- a/src/parser/cosmetic/body/elementhiding.ts
+++ b/src/parser/cosmetic/body/elementhiding.ts
@@ -4,7 +4,7 @@
 
 import {
     fromPlainObject, Selector, SelectorList, SelectorPlain, toPlainObject,
-} from 'css-tree';
+} from '@adguard/ecss-tree';
 import { CSS_SELECTORS_SEPARATOR, SPACE } from '../../../utils/constants';
 import { CssTree } from '../../../utils/csstree';
 import { CssTreeNodeType, CssTreeParserContext } from '../../../utils/csstree-constants';

--- a/src/parser/cosmetic/body/html.ts
+++ b/src/parser/cosmetic/body/html.ts
@@ -4,7 +4,7 @@
 
 import {
     fromPlainObject, Selector, SelectorList, SelectorPlain, toPlainObject,
-} from 'css-tree';
+} from '@adguard/ecss-tree';
 import { AdblockSyntax } from '../../../utils/adblockers';
 import {
     CSS_SELECTORS_SEPARATOR, EMPTY, ESCAPE_CHARACTER, SPACE,

--- a/src/parser/cosmetic/specific/ubo-modifiers.ts
+++ b/src/parser/cosmetic/specific/ubo-modifiers.ts
@@ -5,7 +5,7 @@ import {
     generate as generateCss,
     Selector,
     PseudoClassSelector,
-} from 'css-tree';
+} from '@adguard/ecss-tree';
 import { UBO_COSMETIC_MODIFIERS } from '../../../converter/cosmetic-modifiers';
 import {
     CSS_NOT_PSEUDO,

--- a/src/utils/csstree.ts
+++ b/src/utils/csstree.ts
@@ -14,7 +14,7 @@ import {
     Block,
     CssNodePlain,
     toPlainObject,
-} from 'css-tree';
+} from '@adguard/ecss-tree';
 import { EXTCSS_PSEUDO_CLASSES, EXTCSS_ATTRIBUTES } from '../converter/pseudo';
 import {
     COMMA,

--- a/test/parser/cosmetic/body/css.test.ts
+++ b/test/parser/cosmetic/body/css.test.ts
@@ -1,4 +1,4 @@
-import { MediaQueryListPlain, SelectorPlain } from 'css-tree';
+import { MediaQueryListPlain, SelectorPlain } from '@adguard/ecss-tree';
 import { CssInjectionBodyParser, CssRuleBody, REMOVE_BLOCK_TYPE } from '../../../../src/parser/cosmetic/body/css';
 import { AdblockSyntax } from '../../../../src/utils/adblockers';
 import { EMPTY, SPACE } from '../../../../src/utils/constants';

--- a/test/utils/csstree.test.ts
+++ b/test/utils/csstree.test.ts
@@ -1,4 +1,4 @@
-import { Block, Selector } from 'css-tree';
+import { Block, Selector } from '@adguard/ecss-tree';
 import { CssTree } from '../../src/utils/csstree';
 import { CssTreeParserContext } from '../../src/utils/csstree-constants';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@adguard/ecss-tree@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@adguard/ecss-tree/-/ecss-tree-1.0.8.tgz#9209c2118c88821fc822851153cc042d58abef67"
+  integrity sha512-Y5dfzWH5nnzEH9URuzOQ1RXl0bzmLiGO7Nt9Wc/na7uD5UHqoz4PlzVllFpO1bLA+Cqq5ebNrz+uWRKN3BxSTg==
+  dependencies:
+    css-tree "^2.3.1"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -1360,10 +1367,10 @@
     is-module "^1.0.0"
     resolve "^1.22.1"
 
-"@rollup/plugin-terser@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.2.1.tgz#dcf0b163216dafb64611b170a7667e76a7f03d2b"
-  integrity sha512-hV52c8Oo6/cXZZxVVoRNBb4zh+EKSHS4I1sedWV5pf0O+hTLSkrf6w86/V0AZutYtwBguB6HLKwz89WDBfwGOA==
+"@rollup/plugin-terser@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz#4c76249ad337f3eb04ab409332f23717af2c1fbf"
+  integrity sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==
   dependencies:
     serialize-javascript "^6.0.0"
     smob "^0.0.6"
@@ -1462,11 +1469,6 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/clone-deep/-/clone-deep-4.0.1.tgz#7c488443ab9f571cd343d774551b78e9264ea990"
   integrity sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg==
-
-"@types/css-tree@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/css-tree/-/css-tree-1.0.7.tgz#4483b824a7923d9a7819408a33144014b0c5124c"
-  integrity sha512-Pz+DfVODpQTAV6PwPBK6kzyy7+f6EyPbr1+mYkc1YolJfl2NAJ4wbg0TC/AJPBsqn9jWfyiO19A/sgpvFLfqnw==
 
 "@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.0"
@@ -2158,7 +2160,7 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-tree@^2.2.1:
+css-tree@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
   integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
@@ -4614,10 +4616,10 @@ terminal-link@2.1.1:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser@^5.15.1, terser@^5.16.1:
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.1.tgz#5af3bc3d0f24241c7fb2024199d5c461a1075880"
-  integrity sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==
+terser@^5.15.1:
+  version "5.16.5"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.5.tgz#1c285ca0655f467f92af1bbab46ab72d1cb08e5a"
+  integrity sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
Closes https://github.com/AdguardTeam/AGLint/issues/14

- Integrate ECSSTree
- Add official Rollup plugin for Terser (this was not possible until now due to a plugin issue)
- The entire bundle is only produced in minified form (`aglint.iife.min.js` and `aglint.umd.min.js`)

@maximtop The previous PR was already a conflict hell and the version had to be updated, so I made a new PR