### PR TITLE
Add modifiers [generichide, extension, urlblock, webrtc]

### DIFF
--- a/src/compatibility-tables/modifiers/extension.yml
+++ b/src/compatibility-tables/modifiers/extension.yml
@@ -1,5 +1,5 @@
 adg_os_any:
-  modifier: extension
+  name: extension
   conflicts:
     - domain
     - specifichide

--- a/src/compatibility-tables/modifiers/generichide.yml
+++ b/src/compatibility-tables/modifiers/generichide.yml
@@ -1,5 +1,5 @@
 adg_any:
-  modifier: generichide
+  name: generichide
   aliases:
     - ghide
   conflicts:
@@ -19,7 +19,7 @@ adg_any:
   description: Disables all generic cosmetic rules.
 
 ubo_any:
-  modifier: generichide
+  name: generichide
   aliases:
     - ghide
   conflicts:
@@ -33,7 +33,7 @@ ubo_any:
   description: Disables all generic cosmetic rules.
 
 abp_any:
-  modifier: generichide
+  name: generichide
   conflicts:
     - domain
   inverse_conflicts: true

--- a/src/compatibility-tables/modifiers/urlblock.yml
+++ b/src/compatibility-tables/modifiers/urlblock.yml
@@ -1,5 +1,5 @@
 adg_any:
-  modifier: urlblock
+  name: urlblock
   conflicts:
     - domain
     - specifichide

--- a/src/compatibility-tables/modifiers/webrtc.yml
+++ b/src/compatibility-tables/modifiers/webrtc.yml
@@ -1,17 +1,17 @@
 adg_any:
-  modifier: webrtc
+  name: webrtc
   deprecated: true
   deprecation_message: This modifier is deprecated and is no longer supported. Rules with it are considered as invalid. If you need to suppress WebRTC, consider using the [nowebrtc scriptlet](https://github.com/AdguardTeam/Scriptlets/blob/master/wiki/about-scriptlets.md#nowebrtc).
   docs: https://adguard.com/kb/general/ad-filtering/create-own-filters/#webrtc-modifier
 
 ubo_any:
-  modifier: webrtc
+  name: webrtc
   deprecated: true
   deprecation_message: This modifier is deprecated and is no longer supported. If you need to suppress WebRTC, consider using the [nowebrtc scriptlet](https://github.com/gorhill/uBlock/wiki/Resources-Library#nowebrtcjs-).
   docs: https://github.com/gorhill/uBlock/wiki/Static-filter-syntax
 
 abp_any:
-  modifier: webrtc
+  name: webrtc
   version_added: "1.13.3"
   docs: https://help.adblockplus.org/hc/en-us/articles/360062733293-How-to-write-filters#type-options
   description: The rule applies only to WebRTC connections.


### PR DESCRIPTION
Regarding `adg_os_any`, I don't see it in the documentation (or maybe I just cannot find it), but I saw that is was used in other pull requests.
Maybe it would be a good idea to add it to readme - https://github.com/AdguardTeam/AGLint/tree/master/src/compatibility-tables#readme?