### PR TITLE
Ignore compatibility table yml files in code check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches:
       - master
-    paths-ignore: ['*.md', 'docs/**']
+    paths-ignore:
+      - '**.md'
+      - compatibility-tables/**/*.yml
   pull_request:
     branches:
       - master
-    paths-ignore: ['*.md', 'docs/**']
+    paths-ignore:
+      - '**.md'
+      - compatibility-tables/**/*.yml
 
 jobs:
-  lint:
+  check_code:
     runs-on: ubuntu-latest
     steps:
       - name: Check out to repository


### PR DESCRIPTION
Currently, ESLint / Jest is running unnecessarily because of these YML files.

@ameshkov  suggested another workflow for checking compatibility `*.yml` files, which
1. check the yml syntax and then
2. checks the schema of the file (with Superstruct or something similar tool)

In addition:
- rename `lint` -> `code_check`