### PR TITLE
Fix `paths-ignore` in code check CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,13 +6,13 @@ on:
       - master
     paths-ignore:
       - '**.md'
-      - compatibility-tables/**/*.yml
+      - 'compatibility-tables/**.yml'
   pull_request:
     branches:
       - master
     paths-ignore:
       - '**.md'
-      - compatibility-tables/**/*.yml
+      - 'compatibility-tables/**.yml'
 
 jobs:
   check_code:


### PR DESCRIPTION
`compatibility-tables/**/*.yml` wasn't correct. I debugged it, `'compatibility-tables/**.yml'` definitely skips the YML files.