### PR TITLE
Improve linter rules context type

### DIFF
--- a/src/linter/rules/duplicated-hint-platforms.ts
+++ b/src/linter/rules/duplicated-hint-platforms.ts
@@ -1,5 +1,5 @@
-import { AnyRule, CommentRuleType, RuleCategory } from '../../parser/common';
-import { GenericRuleContext, LinterRule } from '../common';
+import { CommentRuleType, RuleCategory } from '../../parser/common';
+import { LinterRule } from '../common';
 import { SEVERITY } from '../severity';
 
 const PLATFORM = 'PLATFORM';
@@ -13,11 +13,10 @@ export const DuplicatedHintPlatforms: LinterRule = {
         severity: SEVERITY.warn,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
-            // TODO: Remove type assertion
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             if (ast.category === RuleCategory.Comment && ast.type === CommentRuleType.HintCommentRule) {

--- a/src/linter/rules/duplicated-hints.ts
+++ b/src/linter/rules/duplicated-hints.ts
@@ -1,5 +1,5 @@
-import { AnyRule, CommentRuleType, RuleCategory } from '../../parser/common';
-import { GenericRuleContext, LinterRule } from '../common';
+import { CommentRuleType, RuleCategory } from '../../parser/common';
+import { LinterRule } from '../common';
 import { SEVERITY } from '../severity';
 
 /**
@@ -10,11 +10,10 @@ export const DuplicatedHints: LinterRule = {
         severity: SEVERITY.warn,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
-            // TODO: Remove type assertion
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             if (ast.category === RuleCategory.Comment && ast.type === CommentRuleType.HintCommentRule) {

--- a/src/linter/rules/duplicated-modifiers.ts
+++ b/src/linter/rules/duplicated-modifiers.ts
@@ -1,19 +1,19 @@
-import { AnyRule, RuleCategory } from '../../parser/common';
-import { GenericRuleContext, LinterRule } from '../common';
+import { RuleCategory } from '../../parser/common';
+import { LinterRule } from '../common';
 import { SEVERITY } from '../severity';
 
 /**
  * Rule that checks if a network rule contains multiple same modifiers
  */
-export const DuplicatedModifiers = <LinterRule>{
+export const DuplicatedModifiers: LinterRule = {
     meta: {
         severity: SEVERITY.error,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             // Check if the rule is a basic network rule

--- a/src/linter/rules/inconsistent-hint-platforms.ts
+++ b/src/linter/rules/inconsistent-hint-platforms.ts
@@ -1,8 +1,8 @@
-import { GenericRuleContext, LinterRule } from '../common';
+import { LinterRule } from '../common';
 import { SEVERITY } from '../severity';
 import { EMPTY } from '../../utils/constants';
 import { ArrayUtils } from '../../utils/array';
-import { AnyRule, CommentRuleType, RuleCategory } from '../../parser/common';
+import { CommentRuleType, RuleCategory } from '../../parser/common';
 
 const PLATFORM = 'PLATFORM';
 const NOT_PLATFORM = 'NOT_PLATFORM';
@@ -16,11 +16,10 @@ export const InconsistentHintPlatforms: LinterRule = {
         severity: SEVERITY.error,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
-            // TODO: Remove type assertion
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             if (ast.category === RuleCategory.Comment && ast.type === CommentRuleType.HintCommentRule) {

--- a/src/linter/rules/index.ts
+++ b/src/linter/rules/index.ts
@@ -1,4 +1,4 @@
-import { LinterRule } from '../common';
+import { AnyLinterRule } from '../common';
 import { DuplicatedHintPlatforms } from './duplicated-hint-platforms';
 import { DuplicatedHints } from './duplicated-hints';
 import { UnknownHintsAndPlatforms } from './unknown-hints-and-platforms';
@@ -9,7 +9,7 @@ import { InconsistentHintPlatforms } from './inconsistent-hint-platforms';
 import { SingleSelector } from './single-selector';
 import { UnknownPreProcessorDirectives } from './unknown-preprocessor-directives';
 
-export const defaultLinterRules = new Map<string, LinterRule>([
+export const defaultLinterRules = new Map<string, AnyLinterRule>([
     ['if-closed', IfClosed],
     ['single-selector', SingleSelector],
     ['duplicated-modifiers', DuplicatedModifiers],

--- a/src/linter/rules/invalid-domain-list.ts
+++ b/src/linter/rules/invalid-domain-list.ts
@@ -1,6 +1,6 @@
-import { AnyRule, RuleCategory } from '../../parser/common';
+import { RuleCategory } from '../../parser/common';
 import { DomainUtils } from '../../utils/domain';
-import { GenericRuleContext, LinterRule } from '../common';
+import { LinterRule } from '../common';
 import { SEVERITY } from '../severity';
 
 /**
@@ -11,11 +11,10 @@ export const InvalidDomainList: LinterRule = {
         severity: SEVERITY.error,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
-            // TODO: Remove type assertion
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             // Check if the rule is a cosmetic rule (any cosmetic rule)

--- a/src/linter/rules/single-selector.ts
+++ b/src/linter/rules/single-selector.ts
@@ -1,20 +1,20 @@
 import cloneDeep from 'clone-deep';
-import { AnyRule, CosmeticRuleType, RuleCategory } from '../../parser/common';
-import { GenericRuleContext, LinterProblemReport, LinterRule } from '../common';
+import { CosmeticRuleType, RuleCategory } from '../../parser/common';
+import { LinterProblemReport, LinterRule } from '../common';
 import { SEVERITY } from '../severity';
 
 /**
  * Rule that checks if a cosmetic rule contains multiple selectors
  */
-export const SingleSelector = <LinterRule>{
+export const SingleSelector: LinterRule = {
     meta: {
         severity: SEVERITY.warn,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             // Check if the rule is an element hiding rule

--- a/src/linter/rules/unknown-hints-and-platforms.ts
+++ b/src/linter/rules/unknown-hints-and-platforms.ts
@@ -1,6 +1,6 @@
-import { GenericRuleContext, LinterRule } from '../common';
+import { LinterRule } from '../common';
 import { SEVERITY } from '../severity';
-import { AnyRule, CommentRuleType, RuleCategory } from '../../parser/common';
+import { CommentRuleType, RuleCategory } from '../../parser/common';
 
 const NOT_OPTIMIZED = 'NOT_OPTIMIZED';
 const PLATFORM = 'PLATFORM';
@@ -32,11 +32,10 @@ export const UnknownHintsAndPlatforms: LinterRule = {
         severity: SEVERITY.error,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
-            // TODO: Remove type assertion
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             if (ast.category === RuleCategory.Comment && ast.type === CommentRuleType.HintCommentRule) {

--- a/src/linter/rules/unknown-preprocessor-directives.ts
+++ b/src/linter/rules/unknown-preprocessor-directives.ts
@@ -1,6 +1,6 @@
 import { SEVERITY } from '../severity';
-import { GenericRuleContext, LinterRule } from '../common';
-import { AnyRule, CommentRuleType, RuleCategory } from '../../parser/common';
+import { LinterRule } from '../common';
+import { CommentRuleType, RuleCategory } from '../../parser/common';
 
 const COMMON_PREPROCESSOR_DIRECTIVES = [
     'if',
@@ -22,15 +22,15 @@ function isKnownPreProcessorDirective(name: string): boolean {
 /**
  * Rule that checks if a preprocessor directive is known
  */
-export const UnknownPreProcessorDirectives = <LinterRule>{
+export const UnknownPreProcessorDirectives: LinterRule = {
     meta: {
         severity: SEVERITY.error,
     },
     events: {
-        onRule: (context: GenericRuleContext): void => {
+        onRule: (context): void => {
             // Get actually iterated adblock rule
-            const ast = <AnyRule>context.getActualAdblockRuleAst();
-            const raw = <string>context.getActualAdblockRuleRaw();
+            const ast = context.getActualAdblockRuleAst();
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             // Check if the rule is a preprocessor comment

--- a/test/linter/linter.test.ts
+++ b/test/linter/linter.test.ts
@@ -5,7 +5,7 @@ import { defaultLinterRules } from '../../src/linter/rules';
 import { SEVERITY, SeverityValue, SeverityName } from '../../src/linter/severity';
 import { RuleParser } from '../../src/parser/rule';
 import { EMPTY, NEWLINE } from '../../src/utils/constants';
-import { GenericRuleContext, LinterConfig, LinterRule } from '../../src/linter/common';
+import { LinterConfig, LinterRule } from '../../src/linter/common';
 import { AnyRule } from '../../src/parser/common';
 import { FilterListParser } from '../../src/parser/filterlist';
 
@@ -38,8 +38,8 @@ const demoRuleEverythingIsProblem1: LinterRule = {
         severity: SEVERITY.warn,
     },
     events: {
-        onRule: (context: GenericRuleContext) => {
-            const raw = <string>context.getActualAdblockRuleRaw();
+        onRule: (context) => {
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             context.report({
@@ -60,8 +60,8 @@ const demoRuleEverythingIsProblem2: LinterRule = {
         severity: SEVERITY.warn,
     },
     events: {
-        onRule: (context: GenericRuleContext) => {
-            const raw = <string>context.getActualAdblockRuleRaw();
+        onRule: (context) => {
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
 
             context.report({
@@ -90,8 +90,8 @@ const demoRuleEverythingIsProblem3: LinterRule = {
         },
     },
     events: {
-        onRule: (context: GenericRuleContext) => {
-            const raw = <string>context.getActualAdblockRuleRaw();
+        onRule: (context) => {
+            const raw = context.getActualAdblockRuleRaw();
             const line = context.getActualLine();
             const { message } = context.config as { message: string };
 
@@ -2055,8 +2055,8 @@ describe('Linter', () => {
                 severity: SEVERITY.error,
             },
             events: {
-                onRule: (context: GenericRuleContext) => {
-                    const raw = <string>context.getActualAdblockRuleRaw();
+                onRule: (context) => {
+                    const raw = context.getActualAdblockRuleRaw();
                     const line = context.getActualLine();
 
                     context.report({
@@ -2154,8 +2154,8 @@ describe('Linter', () => {
                 severity: SEVERITY.error,
             },
             events: {
-                onRule: (context: GenericRuleContext) => {
-                    const raw = <string>context.getActualAdblockRuleRaw();
+                onRule: (context) => {
+                    const raw = context.getActualAdblockRuleRaw();
                     const line = context.getActualLine();
 
                     context.report({
@@ -2242,8 +2242,8 @@ describe('Linter', () => {
                 severity: SEVERITY.error,
             },
             events: {
-                onRule: (context: GenericRuleContext) => {
-                    const raw = <string>context.getActualAdblockRuleRaw();
+                onRule: (context) => {
+                    const raw = context.getActualAdblockRuleRaw();
                     const line = context.getActualLine();
 
                     context.report({
@@ -2271,8 +2271,8 @@ describe('Linter', () => {
                 severity: SEVERITY.error,
             },
             events: {
-                onRule: (context: GenericRuleContext) => {
-                    const raw = <string>context.getActualAdblockRuleRaw();
+                onRule: (context) => {
+                    const raw = context.getActualAdblockRuleRaw();
                     const line = context.getActualLine();
 
                     context.report({
@@ -2446,7 +2446,7 @@ describe('Linter', () => {
                 },
             },
             events: {
-                onRule: (context: GenericRuleContext) => {
+                onRule: (context) => {
                     config = context.getLinterConfig();
                     content = context.getFilterListContent();
                     rawRules.push(context.getActualAdblockRuleRaw());


### PR DESCRIPTION
Resolve https://github.com/AdguardTeam/AGLint/issues/58.

For the main rule interfaces I added a template to set type for the rule storage (if any) and config (if any).

`onRule` event uses a separate context type (called `SpecificRuleContext` - sorry, I couldn't think of a better name yet). `SpecificRuleContext` extends `GeneralRuleContext`.

Changed `xy = <LinterRule>{` cases to `xy: LinterRule = {` everywhere.

This way we don't need type casts in linter rules.

PS: it might be redundant to pass the AST of the adblock rule as a function, I think a plain `context.ast` prop is enough, I just wanted to follow ESLint very much initially.