### PR TITLE
`aglint init` command, improve build

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,10 @@
 
 import { program } from 'commander';
 import { readFileSync } from 'fs';
-import { LinterCli, LinterConsoleReporter } from '@aglint';
+import { readdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { LinterCli, LinterConsoleReporter } from './index';
+import { CONFIG_FILE_NAMES } from './linter/cli/constants';
 
 // Based on https://github.com/rollup/plugins/tree/master/packages/json#usage
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
@@ -35,16 +38,39 @@ const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url),
         // Parse the arguments
         .parse(process.argv);
 
+    // This specifies in which folder the "npx aglint" / "yarn aglint" command was invoked
+    // and use "process.cwd" as fallback. This is the current working directory (cwd).
+    const cwd = process.env.INIT_CWD || process.cwd();
+
+    // "aglint init": initialize config file in the current directory (cwd)
+    if (program.args[0] === 'init') {
+        // Don't allow to initialize config file if another config file already exists
+        const cwdItems = await readdir(cwd);
+
+        for (const item of cwdItems) {
+            if (CONFIG_FILE_NAMES.includes(item)) {
+                // Show which config file is conflicting exactly
+                // eslint-disable-next-line no-console
+                console.error(`Config file already exists in directory "${cwd}" as "${item}"`);
+                process.exit(1);
+            }
+        }
+
+        // Create the config file
+        // TODO: This is a very basic implementation, we should implement a proper config file generator in the future
+        // eslint-disable-next-line max-len
+        await writeFile(join(cwd, '.aglintrc.yaml'), '# AGLint config file\n# Documentation: https://github.com/AdguardTeam/AGLint#configuration\nextends:\n  - aglint:recommended\n');
+
+        // We should exit the process here, because we don't want to run the linter after initializing the config file
+        process.exit(0);
+    }
+
     // TODO: Custom reporter support with --reporter option
     const cli = new LinterCli(
         new LinterConsoleReporter(program.opts().colors),
         !!program.opts().fix,
         !!program.opts().ignores,
     );
-
-    // This specifies in which folder the "npx aglint" / "yarn aglint" command was invoked
-    // and use "process.cwd" as fallback. This is the current working directory (cwd).
-    const cwd = process.env.INIT_CWD || process.cwd();
 
     await cli.run(cwd, program.args);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,7 @@
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
-        "skipLibCheck": true,
-        "baseUrl": ".",
-        "paths": {
-            "@aglint": ["src/index"]
-        }
+        "skipLibCheck": true
     },
     "include": ["./src/"],
     "exclude": ["./node_modules", "./dist"]


### PR DESCRIPTION
- Implement a very simple `aglint init` command that currently creates a fixed `.aglintrc.yaml` config file. This will need to be improved in the future, but for the time being this might be enough.
- Improve build process, the previously used `@aglint` TS alias confused VSCode import mechanism, but it is no longer needed. The purpose of all this is to avoid bundling the entire library into the CLI tool