### PR TITLE
Pretty print fatal errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,78 +13,122 @@ import { CONFIG_FILE_NAMES } from './linter/cli/constants';
 // Based on https://github.com/rollup/plugins/tree/master/packages/json#usage
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
-(async () => {
-    // Set-up Commander
-    program
-        // Basic info
-        .name('AGLint')
-        .description('Adblock filter list linter')
-        .version(pkg.version, '-v, --version', 'Output the version number')
-        .usage('[options] [file paths...]')
+/**
+ * Print error to the console, also handle unknown errors.
+ *
+ * @param error Error to print
+ */
+function printError(error: unknown): void {
+    const lines = [
+        'Oops! Something went wrong! :(',
+        '',
+        `AGLint: ${pkg.version}`,
+        '',
+    ];
 
-        // Customized help option
-        .helpOption('-h, --help', 'Display help for command')
+    if (error instanceof Error) {
+        const { message, stack } = error;
 
-        // Options
-        .option(
-            '-f, --fix',
-            'Enable automatic fix, if possible (BE CAREFUL, this overwrites original files with the fixed ones)',
-            false,
-        )
-        .option('-c, --colors', 'Force enabling colors', true)
-        .option('--no-colors', 'Force disabling colors')
-        .option('--no-ignores', 'Force ignoring .aglintignore files')
+        lines.push(message || 'No error message provided');
+        lines.push('');
 
-        // Parse the arguments
-        .parse(process.argv);
-
-    // This specifies in which folder the "npx aglint" / "yarn aglint" command was invoked
-    // and use "process.cwd" as fallback. This is the current working directory (cwd).
-    const cwd = process.env.INIT_CWD || process.cwd();
-
-    // "aglint init": initialize config file in the current directory (cwd)
-    if (program.args[0] === 'init') {
-        // Don't allow to initialize config file if another config file already exists
-        const cwdItems = await readdir(cwd);
-
-        for (const item of cwdItems) {
-            if (CONFIG_FILE_NAMES.includes(item)) {
-                // Show which config file is conflicting exactly
-                // eslint-disable-next-line no-console
-                console.error(`Config file already exists in directory "${cwd}" as "${item}"`);
-                process.exit(1);
-            }
-        }
-
-        // Create the config file
-        // TODO: This is a very basic implementation, we should implement a proper config file generator in the future
-        // eslint-disable-next-line max-len
-        await writeFile(join(cwd, '.aglintrc.yaml'), '# AGLint root config file\n# Documentation: https://github.com/AdguardTeam/AGLint#configuration\nroot: true\nextends:\n  - aglint:recommended\n');
-
-        // Notify the user that the config file was created successfully
-        // eslint-disable-next-line no-console
-        console.log(`Config file was created successfully in directory "${cwd}" as ".aglintrc.yaml"`);
-
-        // Notify user about root: true option
-        // eslint-disable-next-line no-console, max-len
-        console.log('Note: "root: true" option was added to the config file. Please make sure that the config file is located in the root directory of your project.');
-
-        // We should exit the process here, because we don't want to run the linter after initializing the config file
-        process.exit(0);
+        // Very basic stack trace formatting
+        lines.push(
+            ...(stack || '').split('\n').map((line) => `  ${line}`),
+        );
+    } else {
+        // Convert any unknown error to string
+        lines.push(String(error));
     }
 
-    // TODO: Custom reporter support with --reporter option
-    const cli = new LinterCli(
-        new LinterConsoleReporter(program.opts().colors),
-        !!program.opts().fix,
-        !!program.opts().ignores,
-    );
+    // Print generated lines to the console as error
+    // eslint-disable-next-line no-console
+    console.error(lines.join('\n'));
+}
 
-    await cli.run(cwd, program.args);
+(async () => {
+    try {
+        // Set-up Commander
+        program
+            // Basic info
+            .name('AGLint')
+            .description('Adblock filter list linter')
+            .version(pkg.version, '-v, --version', 'Output the version number')
+            .usage('[options] [file paths...]')
 
-    // If there are errors, exit with code 1. This is necessary for CI/CD pipelines,
-    // see https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions#about-exit-codes
-    if (cli.hasErrors()) {
-        process.exit(1);
+            // Customized help option
+            .helpOption('-h, --help', 'Display help for command')
+
+            // Options
+            .option(
+                '-f, --fix',
+                'Enable automatic fix, if possible (BE CAREFUL, this overwrites original files with the fixed ones)',
+                false,
+            )
+            .option('-c, --colors', 'Force enabling colors', true)
+            .option('--no-colors', 'Force disabling colors')
+            .option('--no-ignores', 'Force ignoring .aglintignore files')
+
+            // Parse the arguments
+            .parse(process.argv);
+
+        // This specifies in which folder the "npx aglint" / "yarn aglint" command was invoked
+        // and use "process.cwd" as fallback. This is the current working directory (cwd).
+        const cwd = process.env.INIT_CWD || process.cwd();
+
+        // "aglint init": initialize config file in the current directory (cwd)
+        if (program.args[0] === 'init') {
+            // Don't allow to initialize config file if another config file already exists
+            const cwdItems = await readdir(cwd);
+
+            for (const item of cwdItems) {
+                if (CONFIG_FILE_NAMES.includes(item)) {
+                    // Show which config file is conflicting exactly
+                    // eslint-disable-next-line no-console
+                    console.error(`Config file already exists in directory "${cwd}" as "${item}"`);
+                    process.exit(1);
+                }
+            }
+
+            // Create the config file
+            // TODO: This is a very basic implementation, we should implement a proper config
+            // file generator in the future
+            // eslint-disable-next-line max-len
+            await writeFile(join(cwd, '.aglintrc.yaml'), '# AGLint root config file\n# Documentation: https://github.com/AdguardTeam/AGLint#configuration\nroot: true\nextends:\n  - aglint:recommended\n');
+
+            // Notify the user that the config file was created successfully
+            // eslint-disable-next-line no-console
+            console.log(`Config file was created successfully in directory "${cwd}" as ".aglintrc.yaml"`);
+
+            // Notify user about root: true option
+            // eslint-disable-next-line no-console, max-len
+            console.log('Note: "root: true" option was added to the config file. Please make sure that the config file is located in the root directory of your project.');
+
+            // We should exit the process here, because we don't want to run the linter after
+            // initializing the config file
+            process.exit(0);
+        }
+
+        // TODO: Custom reporter support with --reporter option
+        const cli = new LinterCli(
+            new LinterConsoleReporter(program.opts().colors),
+            !!program.opts().fix,
+            !!program.opts().ignores,
+        );
+
+        await cli.run(cwd, program.args);
+
+        // If there are errors, exit with code 1. This is necessary for CI/CD pipelines,
+        // see https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions#about-exit-codes
+        if (cli.hasErrors()) {
+            process.exit(1);
+        }
+    } catch (error: unknown) {
+        // If any error occurs it means that the linter failed to run
+        // Format and print error to the console
+        printError(error);
+
+        // Exit with code 2. This is necessary for CI/CD pipelines
+        process.exit(2);
     }
 })();


### PR DESCRIPTION
If the linter fails to run due to some error, a pretty printed error is displayed instead of the default generated error. I got the idea from ESLint.

AGLint showcase (invalid config):
<details>
<summary>Show screenshot</summary>

![image](https://user-images.githubusercontent.com/57285466/231692741-1ff36f1c-9421-4537-a2a0-f274df108a7d.png)

</details>


ESLint showcase (invalid config):

<details>
<summary>Show screenshot</summary>

![image](https://user-images.githubusercontent.com/57285466/231693864-069b3802-ff60-426e-8466-72b2b00bf42f.png)

</details>
