### PR TITLE
Throw error if the domain list ends with a separator

### DIFF
--- a/src/parser/misc/domain-list.ts
+++ b/src/parser/misc/domain-list.ts
@@ -37,6 +37,17 @@ export class DomainListParser {
             children: [],
         };
 
+        // If the last character is a separator, then the domain list is invalid
+        // and no need to continue parsing
+        const realEndIndex = StringUtils.skipWSBack(raw);
+
+        if (raw[realEndIndex] === separator) {
+            throw new AdblockSyntaxError(
+                'Domain list cannot end with a separator',
+                locRange(loc, realEndIndex, realEndIndex + 1),
+            );
+        }
+
         let offset = 0;
 
         // Skip whitespace before the domain list

--- a/test/parser/misc/domain-list.test.ts
+++ b/test/parser/misc/domain-list.test.ts
@@ -3,7 +3,52 @@ import { DomainList, DomainListSeparator } from '../../../src/parser/common';
 import { COMMA, EMPTY } from '../../../src/utils/constants';
 
 describe('DomainListParser', () => {
-    test('parse', () => {
+    test('parse should throw on invalid input', () => {
+        expect(() => DomainListParser.parse('~')).toThrowError('Empty domain specified');
+
+        expect(() => DomainListParser.parse('~~~')).toThrowError(
+            'Exception marker cannot be followed by another exception marker',
+        );
+
+        expect(() => DomainListParser.parse(' ~ ~ ~ ')).toThrowError(
+            'Exception marker cannot be followed by whitespace',
+        );
+
+        expect(() => DomainListParser.parse('~,~,~')).toThrowError(
+            'Exception marker cannot be followed by a separator',
+        );
+
+        expect(() => DomainListParser.parse('~  example.com')).toThrowError(
+            'Exception marker cannot be followed by whitespace',
+        );
+
+        // https://github.com/AdguardTeam/AGLint/issues/143
+        expect(() => DomainListParser.parse('example.com,')).toThrowError(
+            'Domain list cannot end with a separator',
+        );
+
+        expect(() => DomainListParser.parse('example.com  ,  ')).toThrowError(
+            'Domain list cannot end with a separator',
+        );
+
+        expect(() => DomainListParser.parse('example.com,example.net,')).toThrowError(
+            'Domain list cannot end with a separator',
+        );
+
+        expect(() => DomainListParser.parse(',')).toThrowError(
+            'Domain list cannot end with a separator',
+        );
+
+        expect(() => DomainListParser.parse('example.com,,')).toThrowError(
+            'Domain list cannot end with a separator',
+        );
+
+        expect(() => DomainListParser.parse('example.com , , ')).toThrowError(
+            'Domain list cannot end with a separator',
+        );
+    });
+
+    test('parse should work as expected on valid input', () => {
         // Empty
         expect(DomainListParser.parse(EMPTY)).toEqual<DomainList>(
             {
@@ -629,25 +674,6 @@ describe('DomainListParser', () => {
                 },
             ],
         });
-
-        // Invalid cases
-        expect(() => DomainListParser.parse('~')).toThrowError('Empty domain specified');
-
-        expect(() => DomainListParser.parse('~~~')).toThrowError(
-            'Exception marker cannot be followed by another exception marker',
-        );
-
-        expect(() => DomainListParser.parse(' ~ ~ ~ ')).toThrowError(
-            'Exception marker cannot be followed by whitespace',
-        );
-
-        expect(() => DomainListParser.parse('~,~,~')).toThrowError(
-            'Exception marker cannot be followed by a separator',
-        );
-
-        expect(() => DomainListParser.parse('~  example.com')).toThrowError(
-            'Exception marker cannot be followed by whitespace',
-        );
     });
 
     test('generate', () => {


### PR DESCRIPTION
Closes https://github.com/AdguardTeam/AGLint/issues/143

- Before parsing the domain list, a quick check is performed to detect this case, since it is pointless to parse the input until the end in this case
- In the unit tests, I moved the invalid cases under a separate test case