### PR TITLE
Release both browser builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           files: |
             aglint.tgz
             dist/aglint.iife.min.js
+            dist/aglint.umd.min.js
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
Also release `aglint.umd.min.js`. We also upload the two browser builds as separate release assets, mainly for convenience reasons