### PR TITLE
Resolve build warning

### DIFF
--- a/src/parser/comment/agent.ts
+++ b/src/parser/comment/agent.ts
@@ -1,4 +1,5 @@
-import { coerce, valid } from 'semver';
+import valid from 'semver/functions/valid';
+import coerce from 'semver/functions/coerce';
 import { locRange } from '../../utils/location';
 import { EMPTY, SPACE } from '../../utils/constants';
 import { StringUtils } from '../../utils/string';


### PR DESCRIPTION
Closes https://github.com/AdguardTeam/AGLint/issues/156

Before:
![image](https://user-images.githubusercontent.com/57285466/235896049-8612ad26-891c-4376-97de-12dde23ccb57.png)

After:
![image](https://user-images.githubusercontent.com/57285466/235896012-93e169a0-e394-4461-a500-828f33293548.png)

The trick is to import the function directly, so that no warning is generated during the build.