### PR TITLE
Fix `semver` import

### DIFF
--- a/src/parser/comment/agent.ts
+++ b/src/parser/comment/agent.ts
@@ -1,5 +1,7 @@
-import valid from 'semver/functions/valid';
-import coerce from 'semver/functions/coerce';
+// eslint-disable-next-line import/extensions
+import valid from 'semver/functions/valid.js';
+// eslint-disable-next-line import/extensions
+import coerce from 'semver/functions/coerce.js';
 import { locRange } from '../../utils/location';
 import { EMPTY, SPACE } from '../../utils/constants';
 import { StringUtils } from '../../utils/string';


### PR DESCRIPTION
Rollup just leaves the path unchanged, so in production the CLI doesn't find the two functions for `semver` because ESM requires the extension to be present.

@maximtop Maybe not the "nicest" solution, if you have a better idea, I'd be happy to take it