### PR TITLE
Update integration docs

### DIFF
--- a/docs/repo-integration.md
+++ b/docs/repo-integration.md
@@ -106,8 +106,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
     paths:
       - "**/*.txt"
 

--- a/docs/repo-integration.md
+++ b/docs/repo-integration.md
@@ -105,6 +105,9 @@ on:
       - main
     paths:
       - "**/*.txt"
+      - ".aglintrc.*"
+      - "package.json"
+      - "package-lock.json"
   pull_request:
     branches:
       # TODO: If your default branch is not "main", you should
@@ -112,6 +115,9 @@ on:
       - main
     paths:
       - "**/*.txt"
+      - ".aglintrc.*"
+      - "package.json"
+      - "package-lock.json"
 
 jobs:
   lint:

--- a/docs/repo-integration.md
+++ b/docs/repo-integration.md
@@ -100,11 +100,15 @@ env:
 on:
   push:
     branches:
+      # TODO: If your default branch is not "main", you should
+      # change this to your default branch name, for example: "master"
       - main
     paths:
       - "**/*.txt"
   pull_request:
     branches:
+      # TODO: If your default branch is not "main", you should
+      # change this to your default branch name, for example: "master"
       - main
     paths:
       - "**/*.txt"

--- a/docs/repo-integration.md
+++ b/docs/repo-integration.md
@@ -91,7 +91,7 @@ name: AGLint
 
 # Change the Node.js version if you want
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 
 # AGLint will run on every push and pull request to "main" branch,
 # but only if the changed files contain .txt files

--- a/docs/repo-integration.md
+++ b/docs/repo-integration.md
@@ -91,7 +91,7 @@ name: AGLint
 
 # Change the Node.js version if you want
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 18
 
 # AGLint will run on every push and pull request to "main" branch,
 # but only if the changed files contain .txt files


### PR DESCRIPTION
https://github.com/hufilter/hufilter-dev/pull/390
https://github.com/AdguardTeam/AdguardFilters/pull/157376

- Added TODO comments about default branch (typically `master` <-> `main`)
- Removed `types` from `pull_request` trigger event. If we only use `open`, then AGLint doesn't run when a new commit is pushed to the PR. According to the [GH docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the default behavior is sufficient:
  > By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened
- Added the AGLint config files and the package files to the trigger paths. If push / PR changes any of these, AGLint should run as AGLint config or version may have changed